### PR TITLE
Fixed thread-safety issue happened in Parenscript.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,14 @@
  ChangeLog
 ===========
 
+0.5.0 (2023-03-03)
+==================
+
+* Fixed thread-safety issue happened in Parenscript.
+
+  Parenscript is unsafe yet, the problem should be solved in theЖ
+  https://gitlab.common-lisp.net/parenscript/parenscript/-/issues/11
+
 0.4.0
 =====
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,7 +7,7 @@
 
 * Fixed thread-safety issue happened in Parenscript.
 
-  Parenscript is unsafe yet, the problem should be solved in theЖ
+  Parenscript is unsafe yet, the problem should be solved in the:
   https://gitlab.common-lisp.net/parenscript/parenscript/-/issues/11
 
 0.4.0

--- a/src/reblocks-parenscript.lisp
+++ b/src/reblocks-parenscript.lisp
@@ -1,5 +1,6 @@
-(defpackage reblocks-parenscript
+(uiop:define-package #:reblocks-parenscript
   (:use :cl)
+  (:nicknames #:reblocks-parenscript/reblocks-parenscript)
   (:import-from #:reblocks/dependencies
                 #:local-dependency
                 #:get-url
@@ -9,15 +10,29 @@
                 #:md5)
   (:import-from #:alexandria)
   (:import-from #:parenscript
-                #:chain
-                #:ps
-                #:ps*)
+                #:chain)
+  (:import-from #:bordeaux-threads
+                #:with-lock-held
+                #:make-lock)
 
-  (:export
-   #:make-dependency
-   #:make-dependency*
-   #:make-js-handler))
-(in-package reblocks-parenscript)
+  (:export #:make-dependency
+           #:make-dependency*
+           #:make-js-handler))
+(in-package #:reblocks-parenscript)
+
+
+(defvar *js-compiler-lock*
+  (make-lock "JS Compiler Lock"))
+
+
+(defun ps* (&rest parenscript-code)
+  (with-lock-held (*js-compiler-lock*)
+    (apply #'parenscript:ps* parenscript-code)))
+
+
+(defmacro ps (&body body)
+  `(with-lock-held (*js-compiler-lock*)
+     (parenscript:ps ,@body)))
 
 
 (defclass parenscript-dependency (local-dependency)


### PR DESCRIPTION
Parenscript is unsafe yet, the problem should be solved in the: https://gitlab.common-lisp.net/parenscript/parenscript/-/issues/11